### PR TITLE
DTE-580 default_tags added to terraform provider

### DIFF
--- a/deployments/provider.tf
+++ b/deployments/provider.tf
@@ -4,6 +4,16 @@ provider "aws" {
     role_arn    = var.assume_role
     external_id = var.external_id
   }
+  default_tags {
+    tags = {
+      Environment     = var.environment_name
+      Owner           = "digital-archiving"
+      Terraform       = true
+      TerraformSource = "https://github.com/nationalarchives/tre-terraform-environments"
+      CostCentre      = "56"
+      Role            = "prvt"
+    }
+  }
 }
 
 terraform {


### PR DESCRIPTION
**This will set default tags that will be inherited to all the resources we create using the provider, unless they are overridden by resource or module level tags.**