### PR TITLE
Feature/dte 543/GitHub action env names

### DIFF
--- a/.github/workflows/tf-deployment.yml
+++ b/.github/workflows/tf-deployment.yml
@@ -6,7 +6,7 @@ permissions:
   contents: write
 jobs:
   terraform-dev-deployment:
-    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@main
+    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@feature/DTE-543/github-action-env-names
     with:
       environment: dev
       environment-for-approval: apply-tf-plan-to-dev
@@ -18,7 +18,7 @@ jobs:
   terraform-test-deployment:
     needs:
       - terraform-dev-deployment  
-    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@main
+    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@feature/DTE-543/github-action-env-names
     with:
       environment: test
       environment-for-approval: apply-tf-plan-to-test
@@ -41,7 +41,7 @@ jobs:
   terraform-int-deployment:
     needs:
       - approve
-    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@main
+    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@feature/DTE-543/github-action-env-names
     with:
       environment: int
       environment-for-approval: apply-tf-plan-to-int
@@ -53,7 +53,7 @@ jobs:
   terraform-staging-deployment:
     needs:
       - terraform-int-deployment
-    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@main
+    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@feature/DTE-543/github-action-env-names
     with:
       environment: staging
       environment-for-approval: apply-tf-plan-to-staging
@@ -76,7 +76,7 @@ jobs:
   terraform-prod-deployment:
     needs:
       - prod-approval
-    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@main
+    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@feature/DTE-543/github-action-env-names
     with:
       environment: prod
       environment-for-approval: apply-tf-plan-to-prod

--- a/.github/workflows/tf-deployment.yml
+++ b/.github/workflows/tf-deployment.yml
@@ -1,7 +1,6 @@
 name: Terraform environment deployment
 on:
   workflow_dispatch:
-
 permissions:
   id-token: write
   contents: write
@@ -10,6 +9,7 @@ jobs:
     uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@main
     with:
       environment: dev
+      environment-for-approval: apply-tf-plan-to-dev
       tf_dir: deployments
     secrets:
       ROLE_ARN: ${{ secrets.ROLE_ARN }}
@@ -21,6 +21,7 @@ jobs:
     uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@main
     with:
       environment: test
+      environment-for-approval: apply-tf-plan-to-test
       tf_dir: deployments
     secrets:
       ROLE_ARN: ${{ secrets.ROLE_ARN }}
@@ -30,7 +31,7 @@ jobs:
     needs: 
       - terraform-test-deployment
     runs-on: ubuntu-latest
-    environment: poc-manual-step
+    environment: deployment-checkpoint-int
     steps:
       - name: Manual Approve Info
         run: |
@@ -43,6 +44,7 @@ jobs:
     uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@main
     with:
       environment: int
+      environment-for-approval: apply-tf-plan-to-int
       tf_dir: deployments
     secrets:
       ROLE_ARN: ${{ secrets.ROLE_ARN }}
@@ -54,6 +56,7 @@ jobs:
     uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@main
     with:
       environment: staging
+      environment-for-approval: apply-tf-plan-to-staging
       tf_dir: deployments
     secrets:
       ROLE_ARN: ${{ secrets.ROLE_ARN }}
@@ -63,7 +66,7 @@ jobs:
     needs: 
       - terraform-staging-deployment
     runs-on: ubuntu-latest
-    environment: poc-manual-step
+    environment: deployment-checkpoint-prod
     steps:
       - name: Manual Approve Info
         run: |
@@ -76,6 +79,7 @@ jobs:
     uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@main
     with:
       environment: prod
+      environment-for-approval: apply-tf-plan-to-prod
       tf_dir: deployments
     secrets:
       ROLE_ARN: ${{ secrets.ROLE_ARN }}

--- a/.github/workflows/tf-deployment.yml
+++ b/.github/workflows/tf-deployment.yml
@@ -27,7 +27,7 @@ jobs:
       ROLE_ARN: ${{ secrets.ROLE_ARN }}
       AWS_PARAM_STORE_TF_BACKEND_KEY: ${{ secrets.AWS_PARAM_STORE_TF_BACKEND_KEY }}
       SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-  approve:
+  deploy-to-int-checkpoint:
     needs: 
       - terraform-test-deployment
     runs-on: ubuntu-latest
@@ -40,7 +40,7 @@ jobs:
           echo ${{ github.actor }}
   terraform-int-deployment:
     needs:
-      - approve
+      - deploy-to-int-checkpoint
     uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@feature/DTE-543/github-action-env-names
     with:
       environment: int
@@ -62,7 +62,7 @@ jobs:
       ROLE_ARN: ${{ secrets.ROLE_ARN }}
       AWS_PARAM_STORE_TF_BACKEND_KEY: ${{ secrets.AWS_PARAM_STORE_TF_BACKEND_KEY }}
       SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-  prod-approval:
+  deploy-to-prod-checkpoint:
     needs: 
       - terraform-staging-deployment
     runs-on: ubuntu-latest
@@ -75,7 +75,7 @@ jobs:
           echo ${{ github.actor }}
   terraform-prod-deployment:
     needs:
-      - prod-approval
+      - deploy-to-prod-checkpoint
     uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@feature/DTE-543/github-action-env-names
     with:
       environment: prod

--- a/.github/workflows/tf-deployment.yml
+++ b/.github/workflows/tf-deployment.yml
@@ -6,7 +6,7 @@ permissions:
   contents: write
 jobs:
   terraform-dev-deployment:
-    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@feature/DTE-543/github-action-env-names
+    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@0.0.4
     with:
       environment: dev
       environment-for-approval: apply-tf-plan-to-dev
@@ -18,7 +18,7 @@ jobs:
   terraform-test-deployment:
     needs:
       - terraform-dev-deployment  
-    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@feature/DTE-543/github-action-env-names
+    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@0.0.4
     with:
       environment: test
       environment-for-approval: apply-tf-plan-to-test
@@ -41,7 +41,7 @@ jobs:
   terraform-int-deployment:
     needs:
       - deploy-to-int-checkpoint
-    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@feature/DTE-543/github-action-env-names
+    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@0.0.4
     with:
       environment: int
       environment-for-approval: apply-tf-plan-to-int
@@ -53,7 +53,7 @@ jobs:
   terraform-staging-deployment:
     needs:
       - terraform-int-deployment
-    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@feature/DTE-543/github-action-env-names
+    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@0.0.4
     with:
       environment: staging
       environment-for-approval: apply-tf-plan-to-staging
@@ -76,7 +76,7 @@ jobs:
   terraform-prod-deployment:
     needs:
       - deploy-to-prod-checkpoint
-    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@feature/DTE-543/github-action-env-names
+    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@0.0.4
     with:
       environment: prod
       environment-for-approval: apply-tf-plan-to-prod

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
 # tre-environments
+
+## Deployment Workflow
+
+The Terraform configuration in this repository is deployed automatically by
+the following workflows:
+
+* [tf-deployment.yml](.github/workflows/tf-deployment.yml)
+  * [tf-plan-approve-apply.yml (in tre-github-actions repo)](https://github.com/nationalarchives/tre-github-actions/blob/main/.github/workflows/tf-plan-approve-apply.yml)
+
+The workflow controls deployment to the various AWS environments (`dev`
+through to `prod`) with various manual checkpoints along the way.
+
+The table below shows how the workflow steps relate to both AWS target
+environments and their corresponding GitHub environments
+([tre-terraform-environments/settings/environments](https://github.com/nationalarchives/tre-terraform-environments/settings/environments)).
+The GitHub environments are used in 2 different ways, one is to hold secret
+information for an AWS environment (column "GitHub Environment"), the other is
+to define a list of approval users (column "GitHub Environment for manual
+check"):
+
+| Step | AWS Environment | Step Description    | GitHub Environment | GitHub Environment for manual check |
+| ---- | --------------- | ------------------- | ------------------ | ----------------------------------- |
+|    1 | dev             | terraform plan      | dev                |                                     |
+|    2 |                 | manual user check   |                    | apply-tf-plan-to-dev                |
+|    3 | dev             | terraform apply     | dev                |                                     |
+|    4 | test            | terraform plan      | test               |                                     |
+|    5 |                 | manual user check   |                    | apply-tf-plan-to-test               |
+|    6 | test            | terraform apply     | test               |                                     |
+|    7 |                 | manual user check   |                    | deployment-checkpoint-int           |
+|    8 | int             | plan                | int                |                                     |
+|    9 |                 | manual user check   |                    | apply-tf-plan-to-int                |
+|   10 | int             | terraform apply     | int                |                                     |
+|   11 | staging         | terraform plan      | staging            |                                     |
+|   12 |                 | manual user check   |                    | apply-tf-plan-to-staging            |
+|   13 | staging         | terraform apply     | staging            |                                     |
+|   14 |                 | manual user check   |                    | deployment-checkpoint-prod          |
+|   15 | prod            | terraform plan      | prod               |                                     |
+|   15 |                 | manual user check   |                    | apply-tf-plan-to-prod               |
+|   16 | prod            | terraform apply     | prod               |                                     |


### PR DESCRIPTION
Uses new version of `.github/workflows/tf-plan-approve-apply.yml` (in `tre-github-actions` repo) to specify different GitHub environment names for the `terraform apply` steps of each target AWS environment (`dev` though `prod`).

Updated `int` and `prod` checkpoint names to be consistent.

Also updated README.md to summarise the main workflow and explain the different types of "environments".